### PR TITLE
Route release.yml through metanorma/support wrapper

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,19 +4,44 @@ name: docker
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
   pull_request:
-    paths-ignore:
-      - .gitlab-ci.yml
-      - .github/workflows/test.yml
-      - .github/workflows/generate.yml
-  repository_dispatch:
-    types: [ metanorma/metanorma-docker ]
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  test-docker:
-    uses: metanorma/ci/.github/workflows/sample-docker.yml@main
-    secrets:
-      pat_username: metanorma-ci
-      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: metanorma/metanorma:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Metanorma generate site
+        id: build-and-publish
+        uses: actions-mn/build-and-publish@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          agree-to-terms: true
+          destination: artifact
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions-mn/deploy-pages@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -4,16 +4,33 @@ name: generate
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
   pull_request:
-    paths-ignore:
-      - .gitlab-ci.yml
-      - .github/workflows/test.yml
-      - .github/workflows/docker.yml
   workflow_dispatch:
 
 jobs:
-  test-docker:
-    uses: metanorma/ci/.github/workflows/sample-gen.yml@main
-    secrets:
-      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+  site-generate:
+    name: Generate on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    concurrency:
+      group: '${{ github.workflow }}-${{ matrix.os }}-${{ github.head_ref || github.ref_name }}'
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Setup Metanorma toolchain
+        uses: actions-mn/setup@main
+
+      - name: Metanorma generate site
+        uses: actions-mn/build-and-publish@main
+        with:
+          agree-to-terms: true
+          destination: artifact
+          artifact-name: ${{ github.event.repository.name }}-${{ runner.os }}


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/292
Full plan: https://github.com/metanorma/cimas/blob/main/plans/cimas-revival-and-release-workflow-realignment.md

Routes this repo's `release.yml` through the new `metanorma/support` wrapper, bringing it into alignment with the `<org>/support` pattern already used by `relaton/support`, `fontist/support`, and `lutaml/support`. The `pat_token` reference is dropped (the wrapper does not forward it, matching the convention used by the other org-level support wrappers).

Generated by the cimas-sync wave; canary-verified end-to-end on `metanorma-taste` 1.0.8 (published 2026-06-16 12:54 UTC via the new wrapper path).

🤖
